### PR TITLE
Display the edition icon in the "Edition" column of card lists.

### DIFF
--- a/functions/collection.py
+++ b/functions/collection.py
@@ -164,8 +164,8 @@ def read_coll(box, coll_object):
                         scrolledwindow.set_vexpand(True)
                         scrolledwindow.set_shadow_type(Gtk.ShadowType.IN)
                         
-                        # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", "nb_variant", "nb", unused1, unused2, "coll_ed_nb", "price"
-                        coll_object.mainstore = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float)
+                        # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", "nb_variant", "nb", unused1, unused2, "coll_ed_nb", "price", "edition_code"
+                        coll_object.mainstore = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float, str)
                         tree_coll = Gtk.TreeView(coll_object.mainstore)
                         coll_object.tree_coll = tree_coll
                         tree_coll.set_enable_search(True)
@@ -210,7 +210,7 @@ def read_coll(box, coll_object):
                                 bold_card = dict_rowcards_in_coll[id_][1]
                                 italic_card = dict_rowcards_in_coll[id_][2]
                                 
-                                coll_object.mainstore.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, "", "", card["coll_ed_nb"], card["price"]])
+                                coll_object.mainstore.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, "", "", card["coll_ed_nb"], card["price"], card["edition_code"]])
                         
                         if defs.LANGUAGE in defs.LOC_NAME_FOREIGN.keys():
                                 coll_object.mainstore.set_sort_column_id(3, Gtk.SortType.ASCENDING)
@@ -1173,8 +1173,8 @@ def gen_details_store(selection, object_origin):
                 else:
                         dict_responses_coll[id_card].append([id_coll, date, condition, lang, foil, loaned_to, comment, deck, deck_side])
         if len(dict_responses_coll) > 0:
-                # id_coll, name, editionln, nameforeign, date, condition, lang, foil, loaned_to, comment, deck, bold, italic, id_db, deck_side, unused1, unused2, unused3, unused4, price
-                details_store = Gtk.ListStore(str, str, str, str, str, str, str, str, str, str, str, int, Pango.Style, str, str, str, str, str, str, float)
+                # id_coll, name, editionln, nameforeign, date, condition, lang, foil, loaned_to, comment, deck, bold, italic, id_db, deck_side, unused1, unused2, unused3, unused4, price, edition_code
+                details_store = Gtk.ListStore(str, str, str, str, str, str, str, str, str, str, str, int, Pango.Style, str, str, str, str, str, str, float, str)
                 list_idscoll_added = []
                 for row in pathlist:
                         if object_origin.__class__.__name__ == "Decks":
@@ -1190,6 +1190,7 @@ def gen_details_store(selection, object_origin):
                                         # sideboard detected
                                         card_name = card_name[:-1].replace("|" + defs.STRINGS["decks_sideboard"], "")
                                 card_editionln = model[row][2]
+                                card_edition_code = model[row][20]
                                 card_nameforeign = model[row][3]
                                 if card_nameforeign[0] == "|" and card_nameforeign[-1] == "|":
                                         # sideboard detected
@@ -1210,7 +1211,7 @@ def gen_details_store(selection, object_origin):
                                                         italic = Pango.Style.ITALIC
                                                 
                                                 if str(id_coll) not in list_idscoll_added:
-                                                        details_store.append([str(id_coll), card_name, card_editionln, card_nameforeign, date, condition, lang, foil, loaned_to, comment, deck, bold, italic, card_id, deck_side, "", "", "", "", 0])
+                                                        details_store.append([str(id_coll), card_name, card_editionln, card_nameforeign, date, condition, lang, foil, loaned_to, comment, deck, bold, italic, card_id, deck_side, "", "", "", "", 0, card_edition_code])
                                                         list_idscoll_added.append(str(id_coll))
                         
                 if "name_foreign" in functions.config.read_config("coll_columns").split(";") and defs.LANGUAGE in defs.LOC_NAME_FOREIGN.keys():
@@ -1576,8 +1577,8 @@ def gen_grid_search_coll(coll_object, searchbar, overlay_coll):
                 c.execute(request)
                 reponses_db = c.fetchall()
                 disconnect_db(conn)
-                # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", "nb_variant", "nb", unused1, unused2, "coll_ed_nb", "price"
-                coll_object.searchstore = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float)
+                # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", "nb_variant", "nb", unused1, unused2, "coll_ed_nb", "price", "edition_code"
+                coll_object.searchstore = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float, str)
                 
                 cards = functions.various.prepare_cards_data_for_treeview(reponses_db)
                 nb_results = len(reponses_db)
@@ -1589,7 +1590,7 @@ def gen_grid_search_coll(coll_object, searchbar, overlay_coll):
                         bold_card = dict_rowcards_in_coll[id_][1]
                         italic_card = dict_rowcards_in_coll[id_][2]
                         
-                        coll_object.searchstore.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, "", "", card["coll_ed_nb"], card["price"]])
+                        coll_object.searchstore.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, "", "", card["coll_ed_nb"], card["price"], card["edition_code"]])
                         if card["id_"] not in defs.SDF_VERSO_IDS_LIST:
                                 nb_cards_disp = nb_cards_disp + nb_card
                         else:

--- a/functions/decks.py
+++ b/functions/decks.py
@@ -339,8 +339,8 @@ def gen_deck_content(deck_name, box, decks_object):
                                         nameforeign = "|" + defs.STRINGS["decks_sideboard"] + card["nameforeign"] + "|"
                                         italic_card = Pango.Style.ITALIC
                                 
-                                decksstore.insert_with_valuesv(-1, range(20), [card["id_"], name, card["edition_ln"], nameforeign, card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, 0, side, card["coll_ed_nb"], card["price"]])
-                
+                                decksstore.insert_with_valuesv(-1, range(21), [card["id_"], name, card["edition_ln"], nameforeign, card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, 0, side, card["coll_ed_nb"], card["price"], card["edition_code"]])
+
                         if id_ in dict_proxies_in_deck.keys():
                                 nb_card = dict_proxies_in_deck[id_][0]
                                 bold_card = dict_proxies_in_deck[id_][1]
@@ -353,8 +353,8 @@ def gen_deck_content(deck_name, box, decks_object):
                                         name = "|" + defs.STRINGS["decks_sideboard"] + "-- " + card["name"] + "|"
                                         nameforeign = "|" + defs.STRINGS["decks_sideboard"] + "-- " + card["nameforeign"] + "|"
                                         italic_card = Pango.Style.ITALIC
-                                
-                                decksstore.insert_with_valuesv(-1, range(20), [card["id_"], name, card["edition_ln"], nameforeign, card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, 1, side, card["coll_ed_nb"], card["price"]])
+
+                                decksstore.insert_with_valuesv(-1, range(21), [card["id_"], name, card["edition_ln"], nameforeign, card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold_card, italic_card, card["nb_variant"], nb_card, 1, side, card["coll_ed_nb"], card["price"], card["edition_code"]])
         
         for widget in box.get_children():
                 box.remove(widget)
@@ -454,8 +454,8 @@ def gen_deck_content(deck_name, box, decks_object):
         scrolledwindow.set_vexpand(True)
         scrolledwindow.set_shadow_type(Gtk.ShadowType.IN)
         
-        # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", "nb_variant", "nb", "proxy", "in_sideboard", "coll_ed_nb", "price"
-        decks_object.mainstore = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, int, int, str, float)
+        # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", "nb_variant", "nb", "proxy", "in_sideboard", "coll_ed_nb", "price", "edition_code"
+        decks_object.mainstore = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, int, int, str, float, str)
         tree_deck = Gtk.TreeView(decks_object.mainstore)
         decks_object.maintreeview = tree_deck
         tree_deck.set_enable_search(True)

--- a/functions/various.py
+++ b/functions/various.py
@@ -401,11 +401,11 @@ def prepare_cards_data_for_treeview(cards):
                 name = card[1]
                 # we choose the foreign name
                 nameforeign = card[nb_foreign]
-                
+
                 nameforeign_r = str(nameforeign)
                 names_r = card[3]
                 colors = card[16]
-                
+
                 layout = card[29]
                 if layout == "flip" or layout == "split" or layout == "aftermath":
                         if layout == "flip":
@@ -671,6 +671,17 @@ def get_foreign_name_label():
 
         return foreign__name_label
 
+def _set_edition_icon(_column, cell, list_store, tree_iter, _arg):
+        """Set the 'pixbuf' attribute of a CellRendererPixbuf to the edition icon."""
+        edition_code = list_store[tree_iter][20]
+
+        # TODO: don't reload image each time.
+        image_path = os.path.join(defs.CACHEMCPIC, "icons", valid_filename_os(edition_code) + ".png")
+        if not os.path.isfile(image_path):
+                image_path = os.path.join(defs.PATH_MC, "images", "nothing.png")
+        pixbuf = gdkpixbuf_new_from_file_at_size(image_path, 22, 22)
+        cell.set_property('pixbuf', pixbuf)
+
 def gen_treeview_columns(columns_to_display, treeview):
         """Generates the columns for a treeview which displays cards' data.
 
@@ -706,7 +717,22 @@ def gen_treeview_columns(columns_to_display, treeview):
                 display_column(145, 25, "name", defs.STRINGS["column_english_name"], 1, True)
 
         if "edition" in columns_to_display:
-                display_column(80, 25, "edition", defs.STRINGS["column_edition"], 2, True)
+                edition_column = Gtk.TreeViewColumn(defs.STRINGS["column_edition"])
+
+                renderer_pixbuf_edition = Gtk.CellRendererPixbuf()
+                renderer_pixbuf_edition.set_fixed_size(25, 25)
+                edition_column.pack_start(renderer_pixbuf_edition, False)
+                edition_column.set_cell_data_func(renderer_pixbuf_edition, _set_edition_icon)
+
+                renderer_text_edition = Gtk.CellRendererText()
+                renderer_text_edition.set_fixed_size(80, 25)
+                edition_column.pack_start(renderer_text_edition, True)
+                dict_renderers_list["edition"] = renderer_text_edition
+                edition_column.set_attributes(renderer_text_edition, text=2, weight=w, style=s)
+
+                dict_columns_list["edition"] = edition_column
+                edition_column.set_sort_column_id(2)
+                edition_column.set_expand(True)
 
         if "name_foreign" in columns_to_display:
                 foreign__name_label = get_foreign_name_label()
@@ -819,8 +845,8 @@ def create_window_search_name(request_response, current_object_view):
         scrolledwindow.set_hexpand(True)
         scrolledwindow.set_vexpand(True)
         scrolledwindow.set_shadow_type(Gtk.ShadowType.IN)
-        # "id", "name", "edition", "name_nonenglish", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", unused1, unused2, unused3, unused4, "coll_ed_nb", "price"
-        store_results = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float)
+        # "id", "name", "edition", "name_nonenglish", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", unused1, unused2, unused3, unused4, "coll_ed_nb", "price", "edition_code"
+        store_results = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float, str)
         tree_results = Gtk.TreeView(store_results)
         tree_results.set_enable_search(True)
         if defs.LANGUAGE in defs.LOC_NAME_FOREIGN.keys():
@@ -896,7 +922,7 @@ def create_window_search_name(request_response, current_object_view):
                         add = False
                 
                 if add:
-                        store_results.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold, italic, "", 0, "", "", card["coll_ed_nb"], 0])
+                        store_results.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold, italic, "", 0, "", "", card["coll_ed_nb"], 0, card["edition_code"]])
                         cards_added.append(card["name"] + "-" + card["nb_variant"] + "-" + card["edition_ln"])
                         nb += 1
         

--- a/objects/AdvancedSearch.py
+++ b/objects/AdvancedSearch.py
@@ -293,7 +293,7 @@ class AdvancedSearch:
                 """
                 
                 def insert_data(store_results, cards_added, card, bold, italic):
-                        store_results.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold, italic, "", 0, "", "", card["coll_ed_nb"], card["price"]])
+                        store_results.insert_with_valuesv(-1, range(21), [card["id_"], card["name"], card["edition_ln"], card["nameforeign"], card["colors"], card["pix_colors"], card["cmc"], card["type_"], card["artist"], card["power"], card["toughness"], card["rarity"], bold, italic, "", 0, "", "", card["coll_ed_nb"], card["price"], card["edition_code"]])
                         cards_added.append(card["name"] + "-" + card["nb_variant"] + "-" + card["edition_ln"])
                         functions.various.force_update_gui(0)
                 
@@ -369,8 +369,8 @@ class AdvancedSearch:
                                 functions.various.force_update_gui(0)
                                        
                         scrolledwindow = Gtk.ScrolledWindow()
-                        # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", unused1, unused2, unused3, unused4, "coll_ed_nb", "price"
-                        store_results = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float)
+                        # "id", "name", "edition", "name_foreign", "colors", colors_pixbuf, "cmc", "type", "artist", "power", "toughness", "rarity", "bold", "italic", unused1, unused2, unused3, unused4, "coll_ed_nb", "price", "edition_code"
+                        store_results = Gtk.ListStore(str, str, str, str, str, GdkPixbuf.Pixbuf, int, str, str, str, str, str, int, Pango.Style, str, int, str, str, str, float, str)
                         tree_results = _start(self, store_results, scrolledwindow)
                         cards_added = []
                         


### PR DESCRIPTION
Hi mirandir,

I've added the edition icon for a better look of the card lists.
Feel free to to ask me for changes or any details. 

The code has been tested on Linux only, but it should work on Windows as well.

---
A column containing the edition code has been added to each Gtk.ListStore representing a list of cards.
The display of the tree views (in `gen_treeview_columns()`) has been modified to display both the edition icon and the edition name in the edition column.